### PR TITLE
don't show all avatars in topic list for large sizes

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -13,3 +13,16 @@
 .avatar {
     border-radius: #{$avatars_border_radius} !important;
 }
+
+.topic-list .posters {
+  width: unset;
+  &.theme-avatar-large, &.theme-avatar-extra_large, &.theme-avatar-huge {
+    width: auto;
+    a:not(.latest) {
+      display: none;
+    }
+  }
+  &.theme-avatar-tiny, &.theme-avatar-small, &.theme-avatar-medium {
+      width: 146px;
+  }
+}

--- a/common/head_tag.html
+++ b/common/head_tag.html
@@ -3,7 +3,7 @@
 </script>
 
 <script type="text/x-handlebars" data-template-name="list/posters-column.raw">
-<td class='posters'>
+<td class='posters theme-avatar-{{themeSettings.latest_avatar_size}}'>
   {{#each posters as |poster|}}
     <a href="{{poster.user.path}}" data-user-card="{{poster.user.username}}" class="{{poster.extraClasses}}">
       {{avatar poster avatarTemplatePath="user.avatar_template" usernamePath="user.username" imageSize=themeSettings.latest_avatar_size}}

--- a/settings.yml
+++ b/settings.yml
@@ -34,7 +34,7 @@ latest_avatar_size:
     - small
     - medium
     - large
-    - extra-large
+    - extra_large
     - huge
   description:
     en: "Choose the avatar size on latest. Default value is small (25px)."


### PR DESCRIPTION
I thought I could use SASS functions for this, but I couldn't because the avatar size change happens after SASS is compiled, so instead I added a class with the avatar size to `.posters`. 

Also fixed `extra_large` because `extra-large` didn't work. 